### PR TITLE
Minor performance improvements

### DIFF
--- a/envrc.el
+++ b/envrc.el
@@ -173,16 +173,18 @@ environments updated."
     ;; TODO: if no env-dir?
     (when env-dir
       (let* ((cache-key (envrc--cache-key env-dir process-environment))
-             (result (pcase (gethash cache-key envrc--cache 'missing)
-                       (`missing (let ((calculated (envrc--create-env env-dir)))
-                                   (puthash cache-key calculated envrc--cache)
-                                   calculated))
-                       (cached cached))))
+             vars-were-calculated
+             (result (or (gethash cache-key envrc--cache)
+                         (let ((calculated (envrc--create-env env-dir)))
+                           (setq vars-were-calculated t)
+                           (puthash cache-key calculated envrc--cache)
+                           calculated))))
         (envrc--apply (current-buffer) result)
-        ;; We assume direnv and envrc's use of it is idempotent, and
-        ;; add a cache entry for the new process-environment on that
-        ;; basis.
-        (puthash (envrc--cache-key env-dir process-environment) result envrc--cache)))))
+        (when vars-were-calculated
+          ;; We assume direnv and envrc's use of it is idempotent, and
+          ;; add a cache entry for the new process-environment on that
+          ;; basis.
+          (puthash (envrc--cache-key env-dir process-environment) result envrc--cache))))))
 
 (defmacro envrc--at-end-of-special-buffer (name &rest body)
   "At the end of `special-mode' buffer NAME, execute BODY.

--- a/envrc.el
+++ b/envrc.el
@@ -106,7 +106,8 @@ e.g. (define-key envrc-mode-map (kbd \"C-c e\") 'envrc-command-map)"
   :keymap envrc-mode-map
   (if envrc-mode
       (envrc--update)
-    (envrc--clear (current-buffer))))
+    (envrc--clear (current-buffer))
+    (kill-local-variable 'envrc--status)))
 
 ;;;###autoload
 (define-globalized-minor-mode envrc-global-mode envrc-mode


### PR DESCRIPTION
Commit `Clear envrc--status on mode exit` is a minor correctness fix.

The other two commits are strict performance improvements and don't change runtime behaviour.
Both changes apply to the hot path of setting up a new buffer before it's displayed to the user, which is always worth optiziming.
I've run these changes on my system for the last few weeks.

This package is a joy to use, thank you for sharing it!