### PR TITLE
Consider resetting process-environment before merging

### DIFF
--- a/envrc.el
+++ b/envrc.el
@@ -293,6 +293,7 @@ also appear in PAIRS."
           (envrc--clear buf)
           (envrc--debug "[%s] reset environment to default" buf))
       (envrc--debug "[%s] applied merged environment" buf)
+      (kill-local-variable 'process-environment)
       (setq-local process-environment (envrc--merged-environment process-environment result))
       (let ((path (getenv "PATH"))) ;; Get PATH from the merged environment: direnv may not have changed it
         (setq-local exec-path (parse-colon-path path))


### PR DESCRIPTION
There are two problems.
The first one:
create .envrc with `export MYVAR=45`
`M-x envrc-allow`
`M-x getenv MYVAR => 45`
After that remove or rename `MYVAR`
`M-x envrc-allow`
`M-x getenv MYVAR => 45`
But I expected that `MYVAR` is gone from my environment.
Another problem is excessive calls to `direnv export`.
Call `envrc-reload` multiple times. 
Create a file `temp` in the same directory.
change .envrc e.g. add `export MYVAR_2=56` and reload `M-x envrc-allow`
You can see in `*Messages*` multiple lines like this

```
Running direnv in /tmp/tempdir/...
Direnv succeeded in /tmp/tempdir/
Running direnv in /tmp/tempdir/...
Direnv succeeded in /tmp/tempdir/
```
Why is it called multiple times? You can print cache keys for each buffer and see multiple MYVAR and MYVAR_2 for .envrc buffer and only MYVAR_2 for new buffer.
in `envrc--update` 

```elisp
(`missing (let ((calculated (envrc--export env-dir)))
                                     (with-temp-file (concat "/tmp/env/" (buffer-name))
                                       (insert cache-key))
                                       ...
                                     
                                     ))
```
```bash
cd /tmp/env/
sed -i 's/\x0/\n/g' {.envrc,temp}
grep '^MYVAR' temp | wc -l # 4
grep '^MYVAR' .envrc | wc -l # 6
```

