### PR TITLE
Force ert to exit with a non 0 errcode + errmsg in case of test failure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ INIT_PACKAGES="(progn \
 all: compile test package-lint clean-elc
 
 test:
-	${EMACS} -Q --eval ${INIT_PACKAGES} -batch -l envrc.el -l envrc-tests.el --eval "(ert t)"
+	${EMACS} -Q --eval ${INIT_PACKAGES} -batch -l envrc.el -l envrc-tests.el --eval -f ert-run-tests-batch-and-exit
 
 package-lint:
 	${EMACS} -Q --eval ${INIT_PACKAGES} -batch -f package-lint-batch-and-exit envrc.el


### PR DESCRIPTION
Hello,

Yet another happy silent `envrc` user here! 

I may or may not have scavenged the rather minimal CI  part of this project for a project of mine :stuck_out_tongue: 

I found two issues with it:

1. the `make test` exit code does not reflect the `ert` test status (success/failure).
2. the `make compile` exit code does not reflects the `batch-byte-compile` status code.

This PR fixes point 1. I did not manage to fix the second issue.

```
Force ert to exit with a non 0 errcode + errmsg in case of test failure

As it was, `make test` couldn't exit with a non 0 exit code, even in
case of an error. Github actions are relying on the job exit code to
associate a success code. Meaning, the testsuite couldn't ever fail.

Always green CI is highly desirable, but in that case, the status was
perhaps a bit misleading :P

Note: we have the same issue with the batch-byte-compile function. I
couldn't find an easy fix for that one.
```