### PR TITLE
makefile: remove extra --eval in make test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ INIT_PACKAGES="(progn \
 all: compile test package-lint clean-elc
 
 test:
-	${EMACS} -Q --eval ${INIT_PACKAGES} -batch -l envrc.el -l envrc-tests.el --eval -f ert-run-tests-batch-and-exit
+	${EMACS} -Q --eval ${INIT_PACKAGES} -batch -l envrc.el -l envrc-tests.el -f ert-run-tests-batch-and-exit
 
 package-lint:
 	${EMACS} -Q --eval ${INIT_PACKAGES} -batch -f package-lint-batch-and-exit envrc.el


### PR DESCRIPTION
Apologies, I should have run `make test` before opening the original PR…

Fixing my 0f4e44d7f177e201b470d2870a11583eeb6e4073 screwup. I failed
the copy/paste from my project and left a --eval too much :(