### PR TITLE
Add use_flake to envrc-file-extra-keywords

### DIFF
--- a/envrc.el
+++ b/envrc.el
@@ -398,7 +398,7 @@ in a temp buffer.  ARGS is as for ORIG."
   '("MANPATH_add" "PATH_add" "direnv_layout_dir" "direnv_load" "dotenv"
     "expand_path" "find_up" "has" "join_args" "layout" "load_prefix"
     "log_error" "log_status" "path_add" "rvm" "source_env" "source_up"
-    "use" "use_guix" "use_nix" "user_rel_path" "watch_file")
+    "use" "use_guix" "use_flake" "use_nix" "user_rel_path" "watch_file")
   "Useful direnv keywords to be highlighted.")
 
 ;;;###autoload


### PR DESCRIPTION
This has been in the stdlib since
https://github.com/direnv/direnv/commit/02b6d383f9680c29b9c09b0950c43c0ef4569bec.