### PR TITLE
add new stdlib keywords

### DIFF
--- a/envrc.el
+++ b/envrc.el
@@ -395,10 +395,13 @@ in a temp buffer.  ARGS is as for ORIG."
 ;;; Major mode for .envrc files
 
 (defvar envrc-file-extra-keywords
-  '("MANPATH_add" "PATH_add" "direnv_layout_dir" "direnv_load" "dotenv"
-    "expand_path" "find_up" "has" "join_args" "layout" "load_prefix"
-    "log_error" "log_status" "path_add" "rvm" "source_env" "source_up"
-    "use" "use_guix" "use_flake" "use_nix" "user_rel_path" "watch_file")
+  '("MANPATH_add" "PATH_add" "PATH_rm" "direnv_apply_dump" "direnv_layout_dir"
+    "direnv_load" "direnv_version" "dotenv" "dotenv_if_exists"
+    "env_vars_required" "expand_path" "fetchurl" "find_up" "has" "join_args"
+    "layout" "load_prefix" "log_error" "log_status" "on_git_branch" "path_add"
+    "path_rm" "rvm" "semver_search" "source_env" "source_env_if_exists"
+    "source_up" "source_up_if_exists" "source_url" "strict_env" "unstrict_env"
+    "use" "user_rel_path" "watch_dir" "watch_file")
   "Useful direnv keywords to be highlighted.")
 
 ;;;###autoload


### PR DESCRIPTION
The [stdlib](https://github.com/direnv/direnv/blob/master/stdlib.sh) has added a lot of new functions since the keywords were last added to `envrc-file-extra-keywords`. This PR updates it.