### PR TITLE
Fix accidentally quoted `envrc-direnv-executable` and use the custom variable in tests.

### DIFF
--- a/envrc-tests.el
+++ b/envrc-tests.el
@@ -35,7 +35,7 @@
 
 
 (defun envrc-tests--exec (&rest args)
-  (should (apply 'call-process "direnv" nil nil nil args)))
+  (should (apply 'call-process envrc-direnv-executable nil nil nil args)))
 
 (defmacro envrc-tests--with-extra-global-env-var (key val &rest body)
   "Temporarily set var KEY to VAL in the global `process-environment', while BODY is evaluated."
@@ -79,7 +79,7 @@
 
 (ert-deftest envrc-direnv-is-available ()
   "Check the executable is executable!"
-  (should (executable-find "direnv")))
+  (should (executable-find envrc-direnv-executable)))
 
 (ert-deftest envrc-no-op-unless-allowed ()
   "When the .envrc isn't allowed, do nothing."

--- a/envrc.el
+++ b/envrc.el
@@ -234,7 +234,7 @@ variable names and values."
     (unwind-protect
         (let ((default-directory env-dir))
           (with-temp-buffer
-            (let ((exit-code (envrc--call-process-with-global-env' envrc-direnv-executable nil (list t stderr-file) nil "export" "json")))
+            (let ((exit-code (envrc--call-process-with-global-env envrc-direnv-executable nil (list t stderr-file) nil "export" "json")))
               (envrc--debug "Direnv exited with %s and stderr=%S, stdout=%S"
                             exit-code
                             (with-temp-buffer


### PR DESCRIPTION
This appears to fix #48.