### PR TITLE
Fix setting of PATH in eshell for Emacs 29.0.1

### DIFF
--- a/envrc.el
+++ b/envrc.el
@@ -285,7 +285,10 @@ also appear in PAIRS."
   (with-current-buffer buf
     (kill-local-variable 'exec-path)
     (kill-local-variable 'process-environment)
-    (kill-local-variable 'eshell-path-env)))
+    (when (derived-mode-p 'eshell-mode)
+      (if (fboundp 'eshell-set-path)
+          (eshell-set-path (butlast (exec-path)))
+        (kill-local-variable 'eshell-path-env)))))
 
 
 (defun envrc--apply (buf result)
@@ -301,7 +304,9 @@ also appear in PAIRS."
       (let ((path (getenv "PATH"))) ;; Get PATH from the merged environment: direnv may not have changed it
         (setq-local exec-path (parse-colon-path path))
         (when (derived-mode-p 'eshell-mode)
-          (setq-local eshell-path-env path))))))
+          (if (fboundp 'eshell-set-path)
+              (eshell-set-path path)
+            (setq-local eshell-path-env path)))))))
 
 (defun envrc--update-env (env-dir)
   "Refresh the state of the direnv in ENV-DIR and apply in all relevant buffers."


### PR DESCRIPTION
On the Emacs master branch, `eshell-path-env` has been replaced by the function `eshell-set-path`. This causes the eshell path to not be updated by `envrc-mode`. This commit fixes this by using `eshell-set-path` instead, when it is available.