### PR TITLE
Make direnv execution interruptible in a graceful way

### DIFF
--- a/envrc.el
+++ b/envrc.el
@@ -229,20 +229,24 @@ Return value is either 'error, 'none, or an alist of environment
 variable names and values."
   (unless (envrc--env-dir-p env-dir)
     (error "%s is not a directory with a .envrc" env-dir))
-  (message "Running direnv in %s..." env-dir)
+  (message "Running direnv in %s ... (C-g to abort)" env-dir)
   (let ((stderr-file (make-temp-file "envrc"))
         result)
     (unwind-protect
         (let ((default-directory env-dir))
           (with-temp-buffer
-            (let ((exit-code (envrc--call-process-with-global-env envrc-direnv-executable nil (list t stderr-file) nil "export" "json")))
+            (let ((exit-code (condition-case nil
+                                 (envrc--call-process-with-global-env envrc-direnv-executable nil (list t stderr-file) nil "export" "json")
+                               (quit
+                                (message "interrupted!!")
+                                'interrupted))))
               (envrc--debug "Direnv exited with %s and stderr=%S, stdout=%S"
                             exit-code
                             (with-temp-buffer
                               (insert-file-contents stderr-file)
                               (buffer-string))
                             (buffer-string))
-              (if (zerop exit-code)
+              (if (eq 0 exit-code)
                   (progn
                     (message "Direnv succeeded in %s" env-dir)
                     (if (zerop (buffer-size))
@@ -257,9 +261,9 @@ variable names and values."
                   (insert-file-contents (let (ansi-color-context)
                                           (ansi-color-apply stderr-file)))
                   (goto-char (point-max))
-                  (add-face-text-property initial-pos (point) (if (zerop exit-code) 'success 'error)))
+                  (add-face-text-property initial-pos (point) (if (eq 0 exit-code) 'success 'error)))
                 (insert "\n\n")
-                (unless (zerop exit-code)
+                (when (and (numberp exit-code) (/= 0 exit-code))
                   (display-buffer (current-buffer)))))))
       (delete-file stderr-file))
     result))


### PR DESCRIPTION
Related to #6 and #53, some invocations of direnv can take a long time and block envrc.el. Managing all direnv invocations asynchronous would make everything less predictable and much more complex (either conceptually or in actual code terms), but nonetheless, sometimes we _really_ don't want to wait.

With this commit, the user can hit C-g to halt invocation. This was possible before, but Emacs might nonetheless have tried the same thing again immediately. Now, envrc.el treats the interruption as a direnv failure and remembers it, so the user can proceed and reload the environment at their leisure.