### PR TITLE
Add `envrc-post-update-hook`

### DIFF
--- a/envrc.el
+++ b/envrc.el
@@ -79,6 +79,11 @@ Messages are written into the *envrc-debug* buffer."
   "The direnv executable used by envrc."
   :type 'string)
 
+(defcustom envrc-post-update-hook '()
+  "Hook run after updating the local environment."
+  :group 'envrc
+  :type 'hook)
+
 (define-obsolete-variable-alias 'envrc--lighter 'envrc-lighter "2021-05-17")
 
 (defcustom envrc-lighter '(:eval (envrc--lighter))
@@ -201,7 +206,8 @@ environments updated."
                                calculated))
                    (cached cached)))
              'none)))
-      (envrc--apply (current-buffer) result))))
+      (envrc--apply (current-buffer) result)
+      (run-hooks 'envrc-post-update-hook))))
 
 (defmacro envrc--at-end-of-special-buffer (name &rest body)
   "At the end of `special-mode' buffer NAME, execute BODY.


### PR DESCRIPTION
Fixes https://github.com/purcell/envrc/issues/55. The hook is probably called more often than necessary. Is there a better position in the source code of `envrc` for it to be called?

This allows setting (buffer-local) variables from local environment variables. For example,

    (defun my-set-jdtls-path ()
      (setq-local lsp-java-server-install-dir (getenv "JDTLS_PATH")))

    (add-hook 'envrc-post-update-hook 'my-set-jdtls-path)