### PR TITLE
Unconditionally use bash syntax in `enrc-file-mode`

### DIFF
--- a/envrc.el
+++ b/envrc.el
@@ -424,6 +424,7 @@ in a temp buffer.  ARGS is as for ORIG."
   sh-mode "envrc"
   "Major mode for .envrc files as used by direnv.
 \\{envrc-file-mode-map}"
+  (sh-set-shell "bash")
   (font-lock-add-keywords
    nil `((,(regexp-opt envrc-file-extra-keywords 'symbols)
           (0 font-lock-keyword-face)))))


### PR DESCRIPTION
The parent mode of `envrc-file-mode` (`sh-mode`) unconditionally guesses the concrete shell (`via sh--guess-shell`).  The guess is consistently wrong when the visited file does not have a suffix indicating the concrete shell used.  In that case, it guesses from the content of the `SHELL` environment variable.  In my case, `SHELL` is `"/bin/zsh"`, so `sh-mode` (and therefore `envrc-file-mode`) guesses that every `.envrc` is a zsh file.  But `.envrc` always is a bash file.