### PR TITLE
Let info.el parse INFOPATH

### DIFF
--- a/envrc.el
+++ b/envrc.el
@@ -322,7 +322,7 @@ also appear in PAIRS."
           (if (fboundp 'eshell-set-path)
               (eshell-set-path path)
             (setq-local eshell-path-env path))))
-      ;; tell info.el to parse INFOPATH again in case direnv modified it
+      ;; Force info.el to parse INFOPATH again in case direnv modified it
       (when (getenv "INFOPATH") (setq-local Info-directory-list nil)))))
 
 (defun envrc--update-env (env-dir)

--- a/envrc.el
+++ b/envrc.el
@@ -322,8 +322,8 @@ also appear in PAIRS."
           (if (fboundp 'eshell-set-path)
               (eshell-set-path path)
             (setq-local eshell-path-env path))))
-      (when-let ((info-path (getenv "INFOPATH")))
-        (setq-local Info-directory-list (parse-colon-path info-path))))))
+      ;; tell info.el to parse INFOPATH again in case direnv modified it
+      (when (getenv "INFOPATH") (setq-local Info-directory-list nil)))))
 
 (defun envrc--update-env (env-dir)
   "Refresh the state of the direnv in ENV-DIR and apply in all relevant buffers."


### PR DESCRIPTION
See commit message. I came across this using Guix on an Ubuntu host, where [INFOPATH is set with a trailing colon on login](https://salsa.debian.org/debian/guix/-/blob/b1d0628cbedea22f175a463f4c4935d02601bf93/debian/guix.sh#L16-18).