### PR TITLE
Fix `envrc-global-mode` with absolute direnv path

### DIFF
--- a/envrc.el
+++ b/envrc.el
@@ -143,7 +143,7 @@ e.g. (define-key envrc-mode-map (kbd \"C-c e\") \\='envrc-command-map)"
 ;;;###autoload
 (define-globalized-minor-mode envrc-global-mode envrc-mode
   (lambda () (when (and (not (minibufferp)) (not (file-remote-p default-directory))
-                        (executable-find "direnv"))
+                        (executable-find envrc-direnv-executable))
                (envrc-mode 1))))
 
 (defface envrc-mode-line-on-face '((t :inherit success))


### PR DESCRIPTION
Since e0e84964cf5d1096c95940d983e12cb7772b08fe, `envrc-global-mode` no longer works when `envrc-direnv-executable` is customized.

Since it always checks for "direnv", it won't work if direnv is not on the path or if the direnv executable has a different name.