### PR TITLE
Fix woman and man paths

### DIFF
--- a/envrc.el
+++ b/envrc.el
@@ -144,7 +144,7 @@ e.g. (define-key envrc-mode-map (kbd \"C-c e\") \\='envrc-command-map)"
 
 ;;;###autoload
 (define-globalized-minor-mode envrc-global-mode envrc-mode
-  (lambda () (when (and (not (minibufferp)) (not (file-remote-p default-directory))
+  (lambda () (when (and (not (file-remote-p default-directory))
                         (executable-find envrc-direnv-executable))
                (envrc-mode 1))))
 
@@ -475,6 +475,10 @@ in a temp buffer.  ARGS is as for ORIG."
 (advice-add 'shell-command-to-string :around #'envrc-propagate-environment)
 (advice-add 'async-shell-command :around #'envrc-propagate-environment)
 (advice-add 'org-babel-eval :around #'envrc-propagate-environment)
+
+;; NOTE: since this function is meant to be invoked by `completing-read',
+;; `envrc-mode' must be enabled in the minibuffer.
+(advice-add 'Man-completion-table :around #'envrc-propagate-environment)
 
 
 ;;; Major mode for .envrc files


### PR DESCRIPTION
Hello. The following patches fixes the Emacs `woman` and `man` procedures not inheriting the envrc environment.

The fix for `woman` is similar to the one done for the `info-display-manual` procedure, where we needed to flush it's cache.

On the other hand, the `man` command was a bit more tricky to solve. The issue was that the completing-read function that `man` uses, `Man-completion-table`, needs to inherit the environment. This can be solved advising it with `envrc-propagate-environment`, but since it's invoked from the minibuffer, `envrc-mode` mode will be disabled; and the wrapper will not inject the environment. In order to solve it, we need to remove the logic that prevents `envrc-global-mode` to enable `envrc-mode` in the minibuffer.

I hope this helps!