### PR TITLE
Modify mode-line lighter customization

### DIFF
--- a/envrc.el
+++ b/envrc.el
@@ -99,7 +99,7 @@ set to nil, which disables the lighter."
 (put 'envrc-lighter-function 'risky-local-variable t)
 
 (defcustom envrc-lighter
-  '(:eval (unless (null envrc-lighter-function)
+  '(:eval (when envrc-lighter-function
             (funcall envrc-lighter-function envrc--status)))
   "The mode line lighter for `envrc-mode'.
 You can set this to nil to disable the lighter."


### PR DESCRIPTION
This adds a new customizable variable, `envrc-lighter-function` that sits between `envrc-lighter` and `envrc-STATUS-lighter`. This allows overriding `envrc-lighter` without relying on internal definitions (`envrc--status`).

The other benefit of this is that any customization is likely to want to set all three `envrc-STATUS-lighter`, with them being mostly the same, with a small conditional part (as you can see from both `envrc--default-lighter` and my lambda below). While this variable is a `risky-local-variable`, I believe that `envrc-STATUS-lighter` are also risky, because they can also contain `:eval`, no?

If `envrc-lighter-function` is not customized, the existing `envrc-STATUS-lighter` variables should continue to work as they have.

In future, I think this could be the _only_ `-lighter` customizable variable.

I like my minor modes to be pretty minimal, so I use this like
```elisp
(setq envrc-lighter-function
      (lambda (status)
        `(:propertize "🗁" ; looks like GH’s font doesn’t have a glyph for “open folder” 
                      face
                      ,(pcase status
                         ('on 'envrc-mode-line-on-face)
                         ('error 'envrc-mode-line-error-face)
                         (_ 'envrc-mode-line-none-face)))))
```