### PR TITLE
Support async execution

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,12 @@ INIT_PACKAGES := "(progn \
 
 all: compile test package-lint clean-elc
 
-test:
-	${EMACS} -Q --eval $(subst PACKAGES,${DEPS},${INIT_PACKAGES}) -batch -l envrc.el -l envrc-tests.el -f ert-run-tests-batch-and-exit
+test-sync: SYNC_MODE = --eval "(setq envrc-async-processing nil)"
+
+test: test-sync test-async
+
+test-%:
+	${EMACS} -Q --eval $(subst PACKAGES,${DEPS},${INIT_PACKAGES}) ${SYNC_MODE} -batch -l envrc.el -l envrc-tests.el -f ert-run-tests-batch-and-exit
 
 package-lint:
 	${EMACS} -Q --eval $(subst PACKAGES,package-lint,${INIT_PACKAGES}) -batch -f package-lint-batch-and-exit envrc.el

--- a/envrc-tests.el
+++ b/envrc-tests.el
@@ -35,6 +35,8 @@
 
 
 (defun envrc-tests--exec (&rest args)
+  (when envrc-async-processing
+    (sleep-for 0.1))
   (should (apply 'call-process envrc-direnv-executable nil nil nil args)))
 
 (defmacro envrc-tests--with-extra-global-env-var (key val &rest body)
@@ -72,13 +74,19 @@
   (envrc-tests--with-temp-directory _
     (with-temp-buffer
       (envrc-mode 1)
+      (when envrc-async-processing
+        (sleep-for 0.1))
       (should (eq envrc--status 'none))
+      (when envrc-async-processing
+        (sleep-for 0.1))
       (should (not (local-variable-p 'process-environment))))))
 
 
 
 (ert-deftest envrc-direnv-is-available ()
   "Check the executable is executable!"
+  (when envrc-async-processing
+    (sleep-for 0.1))
   (should (executable-find envrc-direnv-executable)))
 
 (ert-deftest envrc-no-op-unless-allowed ()
@@ -88,7 +96,11 @@
       (insert "export FOO=BAR"))
     (with-temp-buffer
       (envrc-mode 1)
+      (when envrc-async-processing
+        (sleep-for 0.1))
       (should (not (local-variable-p 'process-environment)))
+      (when envrc-async-processing
+        (sleep-for 0.1))
       (should (eq envrc--status 'error)))))
 
 (ert-deftest envrc-setting-propagates-when-mode-enabled ()
@@ -101,8 +113,14 @@
 
     (with-temp-buffer
       (envrc-mode 1)
+      (when envrc-async-processing
+        (sleep-for 0.1))
       (should (local-variable-p 'process-environment))
+      (when envrc-async-processing
+        (sleep-for 0.1))
       (should (equal "BAR" (getenv "FOO")))
+      (when envrc-async-processing
+        (sleep-for 0.1))
       (should (eq envrc--status 'on)))))
 
 (ert-deftest envrc-setting-propagates-when-allowed ()
@@ -112,10 +130,18 @@
 
     (with-temp-buffer
       (envrc-mode 1)
+      (when envrc-async-processing
+        (sleep-for 0.1))
       (should (not (local-variable-p 'process-environment)))
       (envrc-allow)
+      (when envrc-async-processing
+        (sleep-for 0.1))
       (should (local-variable-p 'process-environment))
+      (when envrc-async-processing
+        (sleep-for 0.1))
       (should (equal "BAR" (getenv "FOO")))
+      (when envrc-async-processing
+        (sleep-for 0.1))
       (should (eq envrc--status 'on)))))
 
 (ert-deftest envrc-setting-removed-when-denied ()
@@ -126,11 +152,21 @@
 
     (with-temp-buffer
       (envrc-mode 1)
+      (when envrc-async-processing
+        (sleep-for 0.1))
       (should (local-variable-p 'process-environment))
+      (when envrc-async-processing
+        (sleep-for 0.1))
       (should (equal "BAR" (getenv "FOO")))
+      (when envrc-async-processing
+        (sleep-for 0.1))
       (should (eq envrc--status 'on))
       (envrc-deny)
+      (when envrc-async-processing
+        (sleep-for 0.1))
       (should (not (local-variable-p 'process-environment)))
+      (when envrc-async-processing
+        (sleep-for 0.1))
       (should (eq envrc--status 'error)))))
 
 (ert-deftest envrc-reload-existing-buffer ()
@@ -142,11 +178,15 @@
 
     (with-temp-buffer
       (envrc-mode 1)
+      (when envrc-async-processing
+        (sleep-for 0.1))
       (should (equal "BAR" (getenv "FOO")))
       (with-temp-file ".envrc"
         (insert "export FOO=BAZ"))
       (envrc-tests--exec "allow")
       (envrc-reload)
+      (when envrc-async-processing
+        (sleep-for 0.1))
       (should (equal "BAZ" (getenv "FOO"))))))
 
 (ert-deftest envrc-masks-global-var-when-overridden ()
@@ -158,8 +198,12 @@
       (envrc-tests--exec "allow")
 
       (with-temp-buffer
+        (when envrc-async-processing
+          (sleep-for 0.1))
         (should (equal "BANANA" (getenv "FOO")))
         (envrc-mode 1)
+        (when envrc-async-processing
+          (sleep-for 0.1))
         (should (equal "BAR" (getenv "FOO")))))))
 
 (ert-deftest envrc-state-shared-between-buffers-in-dir ()
@@ -171,19 +215,33 @@
 
     (with-temp-buffer
       (envrc-mode 1)
+      (when envrc-async-processing
+        (sleep-for 0.1))
       (should (local-variable-p 'process-environment))
+      (when envrc-async-processing
+        (sleep-for 0.1))
       (should (equal "BAR" (getenv "FOO")))
 
       (envrc-tests--exec "deny")
 
       (with-temp-buffer
         (envrc-mode 1)
+        (when envrc-async-processing
+          (sleep-for 0.1))
         (should (local-variable-p 'process-environment))
+        (when envrc-async-processing
+          (sleep-for 0.1))
         (should (equal "BAR" (getenv "FOO")))
         (envrc-reload)
+        (when envrc-async-processing
+          (sleep-for 0.1))
         (should (eq envrc--status 'error)))
 
+      (when envrc-async-processing
+        (sleep-for 0.1))
       (should (eq envrc--status 'error))
+      (when envrc-async-processing
+        (sleep-for 0.1))
       (should (not (local-variable-p 'process-environment))))))
 
 (ert-deftest envrc-remove-variable ()
@@ -195,10 +253,14 @@
 
     (with-temp-buffer
       (envrc-mode 1)
+      (when envrc-async-processing
+        (sleep-for 0.1))
       (should (equal "BAR" (getenv "FOO")))
       (with-temp-file ".envrc"
         (insert ""))
       (envrc-allow)
+      (when envrc-async-processing
+        (sleep-for 0.1))
       (should (equal nil (getenv "FOO"))))))
 
 (ert-deftest envrc-cache-is-refreshed-if-global-env-changes ()
@@ -210,6 +272,8 @@
 
     (with-temp-buffer
       (envrc-mode 1)
+      (when envrc-async-processing
+        (sleep-for 0.1))
       (should (equal "BAR" (getenv "FOO")))
       (envrc-tests--with-extra-global-env-var (symbol-name (cl-gensym)) "blah"
         (with-temp-file ".envrc"
@@ -219,6 +283,8 @@
           ;; We expect a cache miss, and therefore a refresh
           (envrc--debug "buffer is %S" (current-buffer))
           (envrc-mode 1)
+          (when envrc-async-processing
+            (sleep-for 0.1))
           (should (local-variable-p 'process-environment))
           (should (equal "BAZ" (getenv "FOO"))))
 
@@ -252,6 +318,8 @@
 
       ;; envrc mode is not activated
       (eshell/cd envrc-dir)
+      (when envrc-async-processing
+        (sleep-for 0.1))
       (should (equal nil (getenv "FOO")))
 
       ;; envrc mode is activated with option set to not update env on directory change
@@ -259,6 +327,8 @@
       (let ((envrc-update-on-eshell-directory-change nil))
         (envrc-mode 1))
       (eshell/cd envrc-dir)
+      (when envrc-async-processing
+        (sleep-for 0.1))
       (should (equal nil (getenv "FOO")))
 
       ;; envrc mode is activated and updates environment with default options
@@ -266,15 +336,21 @@
       (envrc-mode -1)
       (envrc-mode 1)
       (eshell/cd envrc-dir)
+      (when envrc-async-processing
+        (sleep-for 0.1))
       (should (equal "BAR" (getenv "FOO")))
 
       ;; environment is cleared when exiting directory
       (eshell/cd current-dir)
+      (when envrc-async-processing
+        (sleep-for 0.1))
       (should (equal nil (getenv "FOO")))
 
       ;; environment is cleared when envrc-mode is disabled
       (eshell/cd envrc-dir)
       (envrc-mode -1)
+      (when envrc-async-processing
+        (sleep-for 0.1))
       (should (equal nil (getenv "FOO"))))))
 
 ;; TODO:


### PR DESCRIPTION
Hello!

This PR adds support for asynchronous execution. Whether to load the environments synchronously or asynchronously can be configured with the variable `envrc-async-processing`.

This also refactors the envrc lighter to replace it with a mode line indicator. This indicator introduces a new loading state, where a spinner hints buffers that are waiting for the environment to load. The widget can be disabled by setting the `envrc-add-to-mode-line-misc-info` variable to nil.

The following screencast demonstrates the async processing as well as the new widget:
![envrc-async-processing-demo](https://github.com/user-attachments/assets/7225c5d2-ee52-446b-a50d-cfc94747dc20)

In the future we could consider implementing a [vtable](https://www.gnu.org/software/emacs/manual/html_mono/vtable.html) buffer to display running async processes, similarly to how [dtached.el](https://sr.ht/~niklaseklund/detached.el/) displays detached processes.

Regards,
Sergio.