### PR TITLE
Fix minibuffer completion

### DIFF
--- a/envrc.el
+++ b/envrc.el
@@ -85,6 +85,23 @@ Messages are written into the *envrc-debug* buffer."
   :group 'envrc
   :type 'boolean)
 
+(defcustom envrc-disable-in-minibuffer nil
+  "Whether or not to load environments in the minibuffer.
+
+A non-nil value will prevent the envrionment from propagating into the
+minibuffer.
+
+This may be desirable when `envrc-async-processing' is nil.  Loading the
+environment synchronously from the minibuffer, will interrupt user input
+until the envronment has been loaded.  This means that `completing-read'
+will not provide completion using the new environment.
+
+When envrc works asynchonously, it is recommended to set this value to
+nil since the user input will not be interrupted during the envrionment
+loading process."
+  :group 'envrc
+  :type 'boolean)
+
 (defcustom envrc-direnv-executable "direnv"
   "The direnv executable used by envrc."
   :type 'string)
@@ -154,7 +171,7 @@ e.g. (define-key envrc-mode-map (kbd \"C-c e\") \\='envrc-command-map)"
   (lambda ()
     (when
         (cond
-         ((minibufferp) nil)
+         ((and (minibufferp) envrc-disable-in-minibuffer) nil)
          ((file-remote-p default-directory)
           (and envrc-remote
                (seq-contains-p


### PR DESCRIPTION
Hello!

This PR adds a new variable to configure whether to enable envrc in the minibuffer.
Allowing environments to propagate to the minibuffer has the advantage of having updated completions from the `completing-read` interface.

This option pairs great with the new `envrc-async-processing` feature provided in #93. When async processing is enabled, the user will never be interrupted while using the minibuffer, so hanging Emacs in the middle of completion is no longer a concern.

Regards,
Sergio.