### PR TITLE
fix: filter nil values when parsing INFOPATH

### DIFF
--- a/envrc.el
+++ b/envrc.el
@@ -392,7 +392,9 @@ also appear in PAIRS."
               (eshell-set-path path)
             (setq-local eshell-path-env path)))
         (when-let ((info-path (getenv-internal "INFOPATH" env)))
-          (setq-local Info-directory-list (parse-colon-path info-path)))))))
+          (setq-local Info-directory-list
+                      (seq-filter #'identity ; Filter-out nil.
+                                  (parse-colon-path info-path))))))))
 
 (defun envrc--update-env (env-dir)
   "Refresh the state of the direnv in ENV-DIR and apply in all relevant buffers."


### PR DESCRIPTION
The Info-directory-list variable is constructed using the parse-colon-path function, which splits paths based on colons (:). When a path contains a double colon (::) or ends with a colon (:), parse-colon-path returns nil to indicate an empty entry. Since Info-directory-list must be a list of strings, it is necessary to filter out these nil values to maintain a valid list structure.