### PR TITLE
fix: `man' not providing completion from the loaded environment

### DIFF
--- a/envrc.el
+++ b/envrc.el
@@ -85,6 +85,15 @@ Messages are written into the *envrc-debug* buffer."
   :group 'envrc
   :type 'boolean)
 
+(defcustom envrc-disable-in-minibuffer nil
+  "Whether or not to load environments in the minibuffer.
+
+A non-nil value will prevent the envrionment from propagating into the
+minibuffer.  Note that `completing-read' will not provide completion
+using the new environment."
+  :group 'envrc
+  :type 'boolean)
+
 (defcustom envrc-direnv-executable "direnv"
   "The direnv executable used by envrc."
   :type 'string)
@@ -154,7 +163,7 @@ e.g. (define-key envrc-mode-map (kbd \"C-c e\") \\='envrc-command-map)"
   (lambda ()
     (when
         (cond
-         ((minibufferp) nil)
+         ((and (minibufferp) envrc-disable-in-minibuffer) nil)
          ((file-remote-p default-directory)
           (and envrc-remote
                (seq-contains-p

--- a/envrc.el
+++ b/envrc.el
@@ -522,6 +522,10 @@ Shortcuts tramp caching direnv sets the exec-path."
     (or envrc--remote-path
         (apply fn vec nil))))
 
+;; NOTE: since this function is meant to be invoked by `completing-read',
+;; `envrc-mode' must be enabled in the minibuffer. This can be configured by
+;; setting `envrc-disable-in-minibuffer' to nil.
+(advice-add 'Man-completion-table :around #'envrc-propagate-environment)
 (advice-add 'shell-command-to-string :around #'envrc-propagate-environment)
 (advice-add 'async-shell-command :around #'envrc-propagate-environment)
 (advice-add 'org-babel-eval :around #'envrc-propagate-environment)


### PR DESCRIPTION
Hello!

This PR adds a new option `envrc-disable-in-minibuffer`, set to nil by default, consider if this default is desired when loading environments synchronously.

This option is needed since the `man` elisp function relies on `completing-read`, which triggers in the minibuffer. Therefore, in order to propagate the environment to `completing-read`, we need to load the envrc environment in the minibuffer.

Regards,
Sergio.