### PR TITLE
Use Tramp remote path

### DIFF
--- a/envrc.el
+++ b/envrc.el
@@ -358,9 +358,12 @@ also appear in PAIRS."
     (kill-local-variable 'info-directory-list)
     (when (derived-mode-p 'eshell-mode)
       (if (fboundp 'eshell-set-path)
-          (eshell-set-path (butlast exec-path))
+          (eshell-set-path
+           (if (file-remote-p default-directory)
+               (with-parsed-tramp-file-name default-directory nil
+                 (tramp-get-remote-path v))
+             (butlast exec-path)))
         (kill-local-variable 'eshell-path-env)))))
-
 
 (defun envrc--apply (buf result)
   "Update BUF with RESULT, which is a result of `envrc--export'."
@@ -378,8 +381,10 @@ also appear in PAIRS."
                                       'tramp-remote-process-environment
                                     'process-environment))
                    result))
-             (path (getenv-internal "PATH" env))
-             (parsed-path (parse-colon-path path)))
+             (parsed-path (if (file-remote-p default-directory)
+                              (with-parsed-tramp-file-name default-directory nil
+                                (tramp-get-remote-path v))
+                            (parse-colon-path (getenv-internal "PATH" env)))))
         (if remote
             (setq-local tramp-remote-process-environment env)
           (setq-local process-environment env))
@@ -389,7 +394,7 @@ also appear in PAIRS."
           (setq-local exec-path parsed-path))
         (when (derived-mode-p 'eshell-mode)
           (if (fboundp 'eshell-set-path)
-              (eshell-set-path path)
+              (eshell-set-path parsed-path)
             (setq-local eshell-path-env path)))
         (when-let ((info-path (getenv-internal "INFOPATH" env)))
           (setq-local Info-directory-list


### PR DESCRIPTION
Hi there

Thank you for the useful package!

I'm not sure how viable this code is in its current state, but I wanted to share a fix I made to get envrc working for my setup. 

When enabling `envrc-mode` in remote buffers, it was overwriting PATH while ignoring the Tramp remote path. This was particularly evident in my setup because I'm using Windows. So opening an eshell at a Linux remote directory and running `echo $PATH` would print out Windows paths. 

To alleviate this, I updated `envrc--clear` and `envrc--apply` to get the current PATH by using `tramp-get-remote-path` when the buffer is remote.

I was also able to workaround this by adding a line like 

```
export PATH="foo:$PATH"
```

to `.envrc`, which would also then force it to load the correct variable since direnv observes that it's changed.

I'll be happy to make the necessary changes to get this fix merged!
