### PR TITLE
Define envrc-global-modes customization

### DIFF
--- a/envrc.el
+++ b/envrc.el
@@ -161,7 +161,8 @@ e.g. (define-key envrc-mode-map (kbd \"C-c e\") \\='envrc-command-map)"
                 envrc-supported-tramp-methods
                 (with-parsed-tramp-file-name default-directory vec vec-method))))
          (t (executable-find envrc-direnv-executable)))
-      (envrc-mode 1))))
+      (envrc-mode 1)))
+  :predicate t)
 
 (defface envrc-mode-line-on-face '((t :inherit success))
   "Face used in mode line to indicate that direnv is in effect.")


### PR DESCRIPTION
Adding `:predicate t` just causes the `envrc-global-modes`
customization to be generated, which allows users to disable
envrc-mode on a per-major-mode basis.

Specifically, I wanted this for `org-mode` because I have some agenda
files in random projects with .envrcs, but I don't want to activate
every single env I have just because I'm opening my org agenda.

(Annoyingly, due to how `define-globalized-minor-mode` interacts with
`normal-mode`, I also had to add `fundamental-mode` to the opt-out
list, not just `org-mode`).