### PR TITLE
Make it possible to configure the modes in which envrc is enabled

### DIFF
--- a/envrc.el
+++ b/envrc.el
@@ -161,7 +161,8 @@ e.g. (define-key envrc-mode-map (kbd \"C-c e\") \\='envrc-command-map)"
                 envrc-supported-tramp-methods
                 (with-parsed-tramp-file-name default-directory vec vec-method))))
          (t (executable-find envrc-direnv-executable)))
-      (envrc-mode 1))))
+      (envrc-mode 1)))
+  :predicate t)
 
 (defface envrc-mode-line-on-face '((t :inherit success))
   "Face used in mode line to indicate that direnv is in effect.")


### PR DESCRIPTION
Adding `:predicate t` here causes emacs to define a new customizable variable `envrc-global-modes`. This defaults to "all modes" but can be configured by the user to enable/disable `envrc-mode` in specific modes.