### PR TITLE
Propagate environment for processes run by vc commands

### DIFF
--- a/envrc.el
+++ b/envrc.el
@@ -517,6 +517,7 @@ Shortcuts tramp caching direnv sets the variable `exec-path'."
 (advice-add 'shell-command :around #'envrc-propagate-environment)
 (advice-add 'org-babel-eval :around #'envrc-propagate-environment)
 (advice-add 'org-export-file :around #'envrc-propagate-environment)
+(advice-add 'vc-do-command :around #'envrc-propagate-environment)
 (advice-add 'tramp-get-connection-buffer :filter-return #'envrc-propagate-tramp-environment)
 (advice-add 'tramp-get-remote-path :around #'envrc-get-remote-path)
 


### PR DESCRIPTION
I noticed that the direnv environment wasn't being used for vc.el
commands, such as vc-next-action which can be used to commit.

Programs that are added to my $PATH via .envrc and which were part of
some git pre-commit hooks were not found before and caused the commit
to fail.  After adding this advice locally, I saw the commit step
correctly run my pre-commit hooks.