### PR TITLE
Correctly identify remote buffers not backed by a file

### DIFF
--- a/envrc.el
+++ b/envrc.el
@@ -374,7 +374,7 @@ also appear in PAIRS."
         (progn
           (envrc--debug "[%s] reset environment to default" buf))
       (envrc--debug "[%s] applied merged environment" buf)
-      (let* ((remote (when-let* ((fn (buffer-file-name buf)))
+      (let* ((remote (when-let* ((fn (or (buffer-file-name buf) default-directory)))
                        (file-remote-p fn)))
              (env (envrc--merged-environment
                    (default-value (if remote


### PR DESCRIPTION
Currently `envrc--apply` will treat remote buffers not backed by a file (Dired, shells, etc) as local—so it will set `process-environment` and `exec-path` instead of `tramp-remote-process-environment` and `envrc--remote-path` in these ephemeral buffers. I am almost certain this is not intentional but please correct me if I'm wrong.

Also, I'm pretty sure `default-directory` should never be nil, so we might want to change the `when-let*` to a plain `let`.